### PR TITLE
Bench: 3501271

### DIFF
--- a/akimbo/src/search.rs
+++ b/akimbo/src/search.rs
@@ -414,6 +414,9 @@ fn pvs(pos: &Position, eng: &mut Engine, mut alpha: i32, mut beta: i32, mut dept
             // reduce less if next ply had few fail highs
             r -= i32::from(eng.plied[eng.ply as usize].4 < 4);
 
+            // reduce more/less based on history score
+            if ms <= MoveScore::HISTORY_MAX { r -= ms / 8192 }
+
             // don't accidentally extend
             r.max(0)
         } else { 0 };


### PR DESCRIPTION
ELO   | 7.07 +- 5.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
GAMES | N: 9136 W: 2432 L: 2246 D: 4458
https://chess.swehosting.se/test/3875/