### PR TITLE
Correction History

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -58,6 +58,13 @@ c_enum!(
 
 c_enum!(File: u64, A = 0x101010101010101, H = Self::A << 7);
 
+c_enum!(
+    CorrectionHistory: i32,
+    GRAIN = 256,
+    SCALE = 256,
+    MAX = CorrectionHistory::GRAIN * 32
+);
+
 const fn rand(mut seed: u64) -> u64 {
     seed ^= seed << 13;
     seed ^= seed >> 7;

--- a/src/position.rs
+++ b/src/position.rs
@@ -16,6 +16,7 @@ pub struct Position {
     rights: u8,
     pub check: bool,
     hash: u64,
+    pawnhash: u64,
     pub phase: i32,
 }
 
@@ -46,6 +47,10 @@ impl Position {
         hash ^ ZobristVals::castling(self.rights) ^ ZobristVals::side(self.stm())
     }
 
+    pub fn pawnhash(&self) -> u64 {
+        self.pawnhash
+    }
+
     fn ksq(&self, side: usize) -> u8 {
         (self.bb[side] & self.bb[Piece::KING]).trailing_zeros() as u8
     }
@@ -58,7 +63,12 @@ impl Position {
         self.bb[side] ^= bit;
 
         // update hash
-        self.hash ^= ZobristVals::piece(side, pc, sq);
+        let hash_val = ZobristVals::piece(side, pc, sq);
+        self.hash ^= hash_val;
+
+        if pc == Piece::PAWN {
+            self.pawnhash ^= hash_val;
+        }
     }
 
     pub fn has_non_pk(&self, side: usize) -> bool {

--- a/src/search.rs
+++ b/src/search.rs
@@ -315,7 +315,7 @@ fn pvs(
     let s_mov = td.plied[td.ply].singular;
     let singular = s_mov != Move::NULL;
     let pc_beta = beta + 256;
-    let static_eval = pos.eval(&mut td.eval_cache);
+    let mut static_eval = pos.eval(&mut td.eval_cache);
 
     let mut eval = static_eval;
     let mut tt_move = Move::NULL;
@@ -352,6 +352,11 @@ fn pvs(
         {
             eval = tt_score;
         }
+    }
+
+    if !singular {
+        static_eval = td.chtable.correct_evaluation(pos, static_eval);
+        eval = td.chtable.correct_evaluation(pos, eval);
     }
 
     // improving heuristic
@@ -695,6 +700,16 @@ fn pvs(
     // checkmate / stalemate
     if legal == 0 {
         return i32::from(pos.check) * (td.ply - Score::MAX);
+    }
+
+    // update corrhist table
+    if !(singular
+        || pos.check
+        || best_move.is_noisy()
+        || bound == Bound::LOWER && best_score <= static_eval
+        || bound == Bound::UPPER && best_score >= static_eval
+    ) {
+        td.chtable.update_correction_history(pos, depth, best_score - static_eval);
     }
 
     // push new entry to hash table

--- a/src/search.rs
+++ b/src/search.rs
@@ -180,7 +180,7 @@ fn qs(pos: &Position, td: &mut ThreadData, mut alpha: i32, beta: i32) -> i32 {
     td.seldepth = td.seldepth.max(td.ply);
 
     let hash = pos.hash();
-    let mut eval = pos.eval(&mut td.eval_cache);
+    let mut eval = td.chtable.correct_evaluation(pos, pos.eval(&mut td.eval_cache));
 
     // probe hash table for cutoff
     if let Some(entry) = td.tt.probe(hash, td.ply) {
@@ -354,7 +354,7 @@ fn pvs(
         if !((eval > tt_score && bound == Bound::LOWER)
             || (eval < tt_score && bound == Bound::UPPER))
         {
-            eval = td.chtable.correct_evaluation(pos, tt_score);
+            eval = tt_score;
         }
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -317,6 +317,10 @@ fn pvs(
     let pc_beta = beta + 256;
     let mut static_eval = pos.eval(&mut td.eval_cache);
 
+    if !singular {
+        static_eval = td.chtable.correct_evaluation(pos, static_eval);
+    }
+
     let mut eval = static_eval;
     let mut tt_move = Move::NULL;
     let mut tt_score = -Score::MAX;
@@ -350,13 +354,8 @@ fn pvs(
         if !((eval > tt_score && bound == Bound::LOWER)
             || (eval < tt_score && bound == Bound::UPPER))
         {
-            eval = tt_score;
+            eval = td.chtable.correct_evaluation(pos, tt_score);
         }
-    }
-
-    if !singular {
-        static_eval = td.chtable.correct_evaluation(pos, static_eval);
-        eval = td.chtable.correct_evaluation(pos, eval);
     }
 
     // improving heuristic
@@ -703,7 +702,8 @@ fn pvs(
     }
 
     // update corrhist table
-    if !(singular
+    if !(
+        singular
         || pos.check
         || best_move.is_noisy()
         || bound == Bound::LOWER && best_score <= static_eval

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -343,14 +343,18 @@ const CHSIZE: usize = 16384;
 
 #[derive(Clone)]
 pub struct CorrectionHistoryTable {
-    table: [[i32; CHSIZE]; 2],
+    table: Box<[[i32; CHSIZE]; 2]>,
+}
+
+impl Default for CorrectionHistoryTable {
+    fn default() -> Self {
+        Self {
+            table: boxed_and_zeroed(),
+        }
+    }
 }
 
 impl CorrectionHistoryTable {
-    pub fn boxed() -> Box<Self> {
-        boxed_and_zeroed()
-    }
-
     pub fn age_entries(&mut self) {
         self.table.iter_mut().flatten().for_each(|x| *x /= 2);
     }

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -22,7 +22,7 @@ pub struct ThreadData<'a> {
     // tables
     pub tt: HashView<'a>,
     pub htable: HistoryTable,
-    pub chtable: Box<CorrectionHistoryTable>,
+    pub chtable: CorrectionHistoryTable,
     pub plied: PlyTable,
     pub ntable: NodeTable,
     pub stack: Vec<u64>,
@@ -43,7 +43,7 @@ impl<'a> ThreadData<'a> {
         tt: &'a HashTable,
         stack: Vec<u64>,
         htable: HistoryTable,
-        chtable: Box<CorrectionHistoryTable>,
+        chtable: CorrectionHistoryTable,
         castling: Castling,
     ) -> Self {
         Self {

--- a/src/thread.rs
+++ b/src/thread.rs
@@ -8,7 +8,7 @@ use crate::{
     moves::Move,
     network::EvalTable,
     position::Position,
-    tables::{HashTable, HashView, HistoryTable, NodeTable, PlyTable},
+    tables::{CorrectionHistoryTable, HashTable, HashView, HistoryTable, NodeTable, PlyTable},
 };
 
 pub struct ThreadData<'a> {
@@ -22,6 +22,7 @@ pub struct ThreadData<'a> {
     // tables
     pub tt: HashView<'a>,
     pub htable: HistoryTable,
+    pub chtable: Box<CorrectionHistoryTable>,
     pub plied: PlyTable,
     pub ntable: NodeTable,
     pub stack: Vec<u64>,
@@ -42,6 +43,7 @@ impl<'a> ThreadData<'a> {
         tt: &'a HashTable,
         stack: Vec<u64>,
         htable: HistoryTable,
+        chtable: Box<CorrectionHistoryTable>,
         castling: Castling,
     ) -> Self {
         Self {
@@ -51,6 +53,7 @@ impl<'a> ThreadData<'a> {
             min_nmp_ply: 0,
             tt: HashView::new(tt),
             htable,
+            chtable,
             plied: PlyTable::default(),
             ntable: NodeTable::default(),
             stack,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -19,13 +19,13 @@ pub fn run_uci() {
     let mut stack = Vec::new();
     let mut tt = HashTable::default();
     let mut htable = HistoryTable::default();
-    let mut chtable = CorrectionHistoryTable::boxed();
+    let mut chtable = CorrectionHistoryTable::default();
     let mut threads = 1;
     tt.resize(16, 1);
 
     // bench for OpenBench
     if let Some("bench") = std::env::args().nth(1).as_deref() {
-        run_bench(&tt, stack, &htable, chtable);
+        run_bench(&tt, stack, &htable, &chtable);
         return;
     }
 
@@ -150,9 +150,9 @@ fn run_perft(commands: Vec<&str>, pos: &Position, castling: &Castling) {
     );
 }
 
-fn run_bench(tt: &HashTable, stack: Vec<u64>, htable: &HistoryTable, chtable: Box<CorrectionHistoryTable>) {
+fn run_bench(tt: &HashTable, stack: Vec<u64>, htable: &HistoryTable, chtable: &CorrectionHistoryTable) {
     let abort = AtomicBool::new(false);
-    let mut td = ThreadData::new(&abort, tt, stack, htable.clone(), chtable, Castling::default());
+    let mut td = ThreadData::new(&abort, tt, stack, htable.clone(), chtable.clone(), Castling::default());
     let mut total_nodes = 0;
     let mut total_time = 0;
     let mut eval = 0i32;
@@ -232,7 +232,7 @@ fn handle_go(
     castling: &Castling,
     stack: Vec<u64>,
     htable: &mut HistoryTable,
-    chtable: &mut Box<CorrectionHistoryTable>,
+    chtable: &mut CorrectionHistoryTable,
     stored_message: &mut Option<String>,
     tt: &HashTable,
     threads: usize,

--- a/src/uci.rs
+++ b/src/uci.rs
@@ -1,7 +1,7 @@
 use crate::frc::Castling;
 use crate::position::Position;
 use crate::search::go;
-use crate::tables::{HashTable, HistoryTable};
+use crate::tables::{CorrectionHistoryTable, HashTable, HistoryTable};
 use crate::thread::ThreadData;
 use crate::util::STARTPOS;
 
@@ -19,12 +19,13 @@ pub fn run_uci() {
     let mut stack = Vec::new();
     let mut tt = HashTable::default();
     let mut htable = HistoryTable::default();
+    let mut chtable = CorrectionHistoryTable::boxed();
     let mut threads = 1;
     tt.resize(16, 1);
 
     // bench for OpenBench
     if let Some("bench") = std::env::args().nth(1).as_deref() {
-        run_bench(&tt, stack, &htable);
+        run_bench(&tt, stack, &htable, chtable);
         return;
     }
 
@@ -57,6 +58,7 @@ pub fn run_uci() {
                 pos = Position::from_fen(STARTPOS, &mut castling);
                 tt.clear(threads);
                 htable.clear();
+                chtable.clear();
             }
             "setoption" => match commands[..] {
                 ["setoption", "name", "Hash", "value", x] => tt.resize(x.parse().unwrap(), threads),
@@ -72,6 +74,7 @@ pub fn run_uci() {
                 &castling,
                 stack.clone(),
                 &mut htable,
+                &mut chtable,
                 &mut stored_message,
                 &tt,
                 threads,
@@ -147,9 +150,9 @@ fn run_perft(commands: Vec<&str>, pos: &Position, castling: &Castling) {
     );
 }
 
-fn run_bench(tt: &HashTable, stack: Vec<u64>, htable: &HistoryTable) {
+fn run_bench(tt: &HashTable, stack: Vec<u64>, htable: &HistoryTable, chtable: Box<CorrectionHistoryTable>) {
     let abort = AtomicBool::new(false);
-    let mut td = ThreadData::new(&abort, tt, stack, htable.clone(), Castling::default());
+    let mut td = ThreadData::new(&abort, tt, stack, htable.clone(), chtable, Castling::default());
     let mut total_nodes = 0;
     let mut total_time = 0;
     let mut eval = 0i32;
@@ -229,6 +232,7 @@ fn handle_go(
     castling: &Castling,
     stack: Vec<u64>,
     htable: &mut HistoryTable,
+    chtable: &mut Box<CorrectionHistoryTable>,
     stored_message: &mut Option<String>,
     tt: &HashTable,
     threads: usize,
@@ -287,7 +291,7 @@ fn handle_go(
     let soft_bound = if mtg == 1 { alloc } else { alloc * 6 / 10 };
 
     // main search thread
-    let mut td = ThreadData::new(&abort, tt, stack.clone(), htable.clone(), *castling);
+    let mut td = ThreadData::new(&abort, tt, stack.clone(), htable.clone(), chtable.clone(), *castling);
     td.max_time = hard_bound;
     td.max_nodes = nodes;
 
@@ -299,7 +303,7 @@ fn handle_go(
         });
 
         for _ in 0..(threads - 1) {
-            let mut sub = ThreadData::new(&abort, tt, stack.clone(), htable.clone(), *castling);
+            let mut sub = ThreadData::new(&abort, tt, stack.clone(), htable.clone(), chtable.clone(), *castling);
             sub.max_time = hard_bound;
             s.spawn(move || go(pos, &mut sub, false, depth, soft_bound as f64, u64::MAX));
         }
@@ -308,5 +312,7 @@ fn handle_go(
     });
 
     *htable = td.htable;
+    *chtable = td.chtable;
+    chtable.age_entries();
     tt.age_up();
 }


### PR DESCRIPTION
Elo   | 7.74 +- 3.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9386 W: 2558 L: 2349 D: 4479
Penta | [77, 1019, 2301, 1210, 86]
https://chess.swehosting.se/test/8491/

Bench: 2256851