### PR TITLE
Use Correction History in QSearch

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -18,12 +18,12 @@ fn eval_side(pos: &Position, side: usize) -> S {
 
     let pawns_bb = pos.piece(Piece::PAWN);
 
-    for piece in Piece::PAWN..=Piece::KING {
+    for (piece, pst) in PST.iter().enumerate().take(Piece::KING + 1).skip(Piece::PAWN) {
         let mut bb = pos.piece(piece) & side_bb;
 
         bitloop!(|bb, sq| {
             let fsq = usize::from(sq) ^ flip;
-            score += PST[piece][fsq];
+            score += pst[fsq];
 
             match piece {
                 Piece::PAWN => {

--- a/src/search.rs
+++ b/src/search.rs
@@ -181,7 +181,7 @@ fn qs(pos: &Position, td: &mut ThreadData, mut alpha: i32, beta: i32) -> i32 {
     td.seldepth = td.seldepth.max(td.ply);
 
     let hash = pos.hash();
-    let mut eval = eval(pos);
+    let mut eval = td.chtable.correct_evaluation(pos, eval(pos));
 
     // probe hash table for cutoff
     if let Some(entry) = td.tt.probe(hash, td.ply) {


### PR DESCRIPTION
Elo   | 25.24 +- 10.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1986 W: 607 L: 463 D: 916
Penta | [29, 212, 408, 274, 70]
https://chess.swehosting.se/test/8492/

Bench: 4509435